### PR TITLE
Fix label in task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: 🤖 Task
 about: Create a Task issue
 title: ''
-labels: ':robot_face: task'
+labels: '🤖 task'
 assignees: ''
 
 ---


### PR DESCRIPTION
When creating a new issue the label was not matching existing labels as the emoji was included incorrectly on the template